### PR TITLE
fix: ignore ExpoConfigAll in fingerprint

### DIFF
--- a/.maestro/FavoritePodcast.yaml
+++ b/.maestro/FavoritePodcast.yaml
@@ -1,6 +1,4 @@
-# Smoke test for our app.
 appId: com.blogapp
-
 ---
 - launchApp
 - assertVisible: "Log In"

--- a/fingerprint.config.js
+++ b/fingerprint.config.js
@@ -1,7 +1,7 @@
 /** @type {import('@expo/fingerprint').Config} */
 const config = {
     sourceSkips: [
-      'ExpoConfigEASProject',
+      'ExpoConfigAll',
     ],
   };
   module.exports = config;


### PR DESCRIPTION
Follow up to https://github.com/coolsoftwaretyler/eas-workflow-blogapp/pull/4. I was hoping that we get a native match with just `ExpoConfigEASProject`, but it didn't work, so I've updated to `ExpoConfigAll` and will check across PRs again.